### PR TITLE
Add NASDAQ RL sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Technical indicators: 'macd', 'boll_ub', 'boll_lb', 'rsi_30', 'dx_30', 'close_30
 ## Tutorials
 
 + [Towardsdatascience] [Deep Reinforcement Learning for Automated Stock Trading](https://towardsdatascience.com/deep-reinforcement-learning-for-automated-stock-trading-f1dad0126a02)
++ [NASDAQ RL Sample](nasdaq_sample/README.md) – minimal project demonstrating training on NASDAQ‑100 data using FinRL and TradingView.
 
 
 ## Publications

--- a/nasdaq_sample/README.md
+++ b/nasdaq_sample/README.md
@@ -1,0 +1,27 @@
+# NASDAQ RL Sample
+
+This directory contains a minimal example for training a reinforcement learning agent on NASDAQ‑100 data using [FinRL](https://github.com/AI4Finance-Foundation/FinRL).
+
+## Installation
+
+Use [uv](https://github.com/astral-sh/uv) to create a virtual environment and install dependencies:
+
+```bash
+uv venv .venv
+source .venv/bin/activate
+uv pip install -r requirements.uv
+```
+
+## Training
+
+Run the training script to download data from Yahoo Finance and train a PPO agent:
+
+```bash
+python train.py
+```
+
+The trained model is stored in `nasdaq_ppo.zip`.
+
+## TradingView Client
+
+`tradingview_client.py` provides a thin wrapper around `tradingview_ta` so you can query TradingView indicators for any NASDAQ ticker. Network access to TradingView may require additional configuration in restricted environments.

--- a/nasdaq_sample/requirements.uv
+++ b/nasdaq_sample/requirements.uv
@@ -1,0 +1,6 @@
+finrl
+stable-baselines3[extra]
+tradingview_ta
+yfinance
+pandas
+numpy

--- a/nasdaq_sample/tradingview_client.py
+++ b/nasdaq_sample/tradingview_client.py
@@ -1,0 +1,15 @@
+"""Simple TradingView client using `tradingview_ta` for analysis."""
+from __future__ import annotations
+
+from tradingview_ta import TA_Handler, Interval
+
+class TradingViewClient:
+    """Wrapper around :mod:`tradingview_ta` to fetch indicators."""
+
+    def __init__(self, symbol: str, exchange: str = "NASDAQ", screener: str = "america", interval: Interval = Interval.INTERVAL_1_DAY) -> None:
+        self.handler = TA_Handler(symbol=symbol, exchange=exchange, screener=screener, interval=interval)
+
+    def get_analysis(self) -> dict:
+        """Return raw indicator analysis from TradingView."""
+        analysis = self.handler.get_analysis()
+        return analysis.indicators

--- a/nasdaq_sample/train.py
+++ b/nasdaq_sample/train.py
@@ -1,0 +1,41 @@
+"""Example training script for NASDAQ-100 stocks using FinRL."""
+from __future__ import annotations
+
+import pandas as pd
+from finrl.meta.data_processor import DataProcessor
+from finrl.meta.env_stock_trading.env_stocktrading_np import StockTradingEnv
+from finrl.config_tickers import NAS_100_TICKER
+from finrl.config import INDICATORS
+from stable_baselines3 import PPO
+from stable_baselines3.common.vec_env import DummyVecEnv
+
+
+START_DATE = "2018-01-01"
+END_DATE = "2020-12-31"
+
+
+def create_env() -> DummyVecEnv:
+    dp = DataProcessor("yahoofinance")
+    data = dp.download_data(NAS_100_TICKER, START_DATE, END_DATE, "1D")
+    data = dp.clean_data(data)
+    data = dp.add_technical_indicator(data, INDICATORS)
+    data = dp.add_vix(data)
+    price_array, tech_array, turbulence_array = dp.df_to_array(data, if_vix=True)
+    env_config = {
+        "price_array": price_array,
+        "tech_array": tech_array,
+        "turbulence_array": turbulence_array,
+        "if_train": True,
+    }
+    return DummyVecEnv([lambda: StockTradingEnv(config=env_config)])
+
+
+def train_agent() -> None:
+    env = create_env()
+    model = PPO("MlpPolicy", env, verbose=1)
+    model.learn(total_timesteps=10_000)
+    model.save("nasdaq_ppo")
+
+
+if __name__ == "__main__":
+    train_agent()


### PR DESCRIPTION
## Summary
- provide a simple NASDAQ RL training sample in `nasdaq_sample`
- include a TradingView client example
- document the sample in the main README

## Testing
- `pytest -q` *(fails: HTTPSConnectionPool(host='data.alpaca.markets', port=443))*

------
https://chatgpt.com/codex/tasks/task_e_684f66afb99883269e3d022cf32250ce